### PR TITLE
tokenizer changed to lazy computation

### DIFF
--- a/_parser/_parser.py
+++ b/_parser/_parser.py
@@ -92,6 +92,8 @@ class Parser:
     @property
     def peek(self) -> Token:
         if len(self.peek_queue) > 0:
+            # Because we just want to see what the next token is without consuming it, return the last value in the
+            # queue without calling .pop()
             return self.peek_queue[-1]
 
         try:

--- a/_parser/_parser.py
+++ b/_parser/_parser.py
@@ -278,7 +278,7 @@ class Parser:
         self.advance()
 
         # Add a semicolon so users don't have to add one in the code
-        # self.add_semicolon()
+        self.add_semicolon()
 
         return Loop(comparison, loop_statements)
 
@@ -311,7 +311,7 @@ class Parser:
             self.is_expected_token(CLOSED_CURLY_BRACKET)
             self.advance()
 
-        # self.add_semicolon()
+        self.add_semicolon()
 
         return IfStatement(comparison, if_statements, else_statements)
 
@@ -350,7 +350,7 @@ class Parser:
         self.is_expected_token(CLOSED_CURLY_BRACKET)
         self.advance()
 
-        # self.add_semicolon()
+        self.add_semicolon()
 
         return AssignFunction(function_name, parameters, function_statements)
 
@@ -431,9 +431,12 @@ class Parser:
                 self.current.line_num,
                 f"Expected {expected_token_type}, got {self.current.type} ('{self.current.value}')")
 
-    # def add_semicolon(self) -> None:
-    #     semicolon_label = "SEMICOLON"
-    #     self.peek_queue.insert(
-    #         0,
-    #         Token(get_token_literal(semicolon_label), get_token_type(semicolon_label), self.current.line_num),
-    #     )
+    def add_semicolon(self) -> None:
+        semicolon_label = "SEMICOLON"
+        semicolon_literal = get_token_literal(semicolon_label)
+        semicolon_type = get_token_type(semicolon_label)
+
+        # To insert a token into the token stream, add the current token to the peek queue, and then update
+        # self.current to the new token
+        self.peek_queue.append(self.current)
+        self.current = Token(semicolon_literal, semicolon_type, self.current.line_num)

--- a/_parser/ast_objects.py
+++ b/_parser/ast_objects.py
@@ -286,7 +286,7 @@ class Integer(Base, Factor):
         return super().less_than(other)
 
     def less_than_or_equal(self, other: "Base") -> "Base":
-        result = self.value >= other.value
+        result = self.value <= other.value
         if isinstance(other, Integer):
             return Boolean(result, self.line_num)
 

--- a/main.py
+++ b/main.py
@@ -20,9 +20,8 @@ def get_source(filepath: str) -> str:
 def evaluate(source: str, environment: Environment, visualize: bool = False) -> typing.Optional[typing.List[Base]]:
     try:
         t = Tokenizer(source)
-        tokens = t.tokenize()
 
-        p = Parser(tokens)
+        p = Parser(t)
         ast = p.parse()
 
         # if visualize:
@@ -32,7 +31,8 @@ def evaluate(source: str, environment: Environment, visualize: bool = False) -> 
         return e.evaluate()
     except LanguageRuntimeException as e:
         print(str(e))
-    return None
+
+    return None  # needed to solve mypy error: Missing return statement
 
 
 def repl(prompt: str = ">>") -> None:

--- a/tests/test_evaluator_integration.py
+++ b/tests/test_evaluator_integration.py
@@ -133,7 +133,7 @@ def test_function_no_return():
     source = """
     func no_return() {
         set x = 1;
-    };
+    }
     
     set var = no_return();
     """
@@ -146,7 +146,7 @@ def test_function_no_return():
 
 def test_function_empty_body_no_return():
     source = """
-    func no_return() {};
+    func no_return() {}
     set var = no_return();
     """
 
@@ -161,8 +161,8 @@ def test_function_return():
     func is_equal(a, b) {
         if (a == b) {
             return true;
-        };
-    };
+        }
+    }
     is_equal(1, 1);  # true
     is_equal(1, 2);  # No return
     """
@@ -188,7 +188,7 @@ def test_function_calls(first_param, second_param, return_val):
     source = f"""
     func add(a, b) {{
         return a + b;
-    }};
+    }}
     add({first_param}, {second_param});
     """
 
@@ -238,7 +238,7 @@ def test_loop():
     set i = 0;
     while i < 10 {
         set i += 1;
-    };
+    }
     i;
     """
     actual_results = actual_result(source)

--- a/tests/test_evaluator_integration.py
+++ b/tests/test_evaluator_integration.py
@@ -42,11 +42,14 @@ valid_boolean_operations_tests = [
     ("1 >= 1;", [o.Boolean(True, 1)]),
     ("1 >= 2;", [o.Boolean(False, 1)]),
     ("1 > 1;",  [o.Boolean(False, 1)]),
+    ("1 > 2;",  [o.Boolean(False, 1)]),
     ("2 > 1;",  [o.Boolean(True, 1)]),
     ("1 <= 1;", [o.Boolean(True, 1)]),
+    ("1 <= 10;", [o.Boolean(True, 1)]),
+    ("10 <= 1;", [o.Boolean(False, 1)]),
     ("1 < 2;",  [o.Boolean(True, 1)]),
     ("2 < 1;",  [o.Boolean(False, 1)]),
-    ("10 == (2 + 4 * 2) == true;",  [o.Boolean(True, 1)])
+    ("10 == 2 + 4 * 2 == true;",  [o.Boolean(True, 1)])
 ]
 
 
@@ -130,7 +133,7 @@ def test_function_no_return():
     source = """
     func no_return() {
         set x = 1;
-    }
+    };
     
     set var = no_return();
     """
@@ -143,7 +146,7 @@ def test_function_no_return():
 
 def test_function_empty_body_no_return():
     source = """
-    func no_return() {}
+    func no_return() {};
     set var = no_return();
     """
 
@@ -158,8 +161,8 @@ def test_function_return():
     func is_equal(a, b) {
         if (a == b) {
             return true;
-        }
-    }
+        };
+    };
     is_equal(1, 1);  # true
     is_equal(1, 2);  # No return
     """
@@ -185,7 +188,7 @@ def test_function_calls(first_param, second_param, return_val):
     source = f"""
     func add(a, b) {{
         return a + b;
-    }}
+    }};
     add({first_param}, {second_param});
     """
 
@@ -235,7 +238,7 @@ def test_loop():
     set i = 0;
     while i < 10 {
         set i += 1;
-    }
+    };
     i;
     """
     actual_results = actual_result(source)
@@ -323,7 +326,7 @@ def test_add_node_to_tree():
     set list = "numbers" => [];
     add_node(list, 1, "");
     list;
-    add_node(list, 2, 1);
+    add_node(list, 2, "1");
     list;
     """
     expected_results = [
@@ -345,9 +348,8 @@ def test_add_node_to_tree():
 
 def actual_result(source):
     t = Tokenizer(source)
-    tokens = t.tokenize()
 
-    p = Parser(tokens)
+    p = Parser(t)
     ast = p.parse()
 
     e = Evaluator(ast, Environment())

--- a/tests/test_parser_integration.py
+++ b/tests/test_parser_integration.py
@@ -1,18 +1,10 @@
 import pytest
 from tokens.tokens import *
-from tokens.tokenizer import Token
+from tokens.tokenizer import Token, Tokenizer
 from _parser import _parser
 
 
 def test_precedence_add():
-
-    tokens = [
-        Token("1", INTEGER, 1),
-        Token("+", PLUS, 1),
-        Token("1", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-        Token("", EOF, 1)
-    ]
 
     expected_ast = [
         _parser.ExpressionStatement(
@@ -24,21 +16,12 @@ def test_precedence_add():
         )
     ]
 
-    actual_ast = _parser.Parser(tokens).parse()
+    tokenizer = Tokenizer("1+1;")
+    actual_ast = _parser.Parser(tokenizer).parse()
     assert actual_ast == expected_ast
 
 
 def test_precedence_multiply():
-    tokens = [
-        Token("1", INTEGER, 1),
-        Token("+", PLUS, 1),
-        Token("2", INTEGER, 1),
-        Token("*", MULTIPLY, 1),
-        Token("4", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-        Token("", EOF, 1)
-    ]
-
     expected_ast = [
         _parser.ExpressionStatement(
             _parser.BinaryOperation(
@@ -53,7 +36,8 @@ def test_precedence_multiply():
         )
     ]
 
-    actual_ast = _parser.Parser(tokens).parse()
+    tokenizer = Tokenizer("1+2*4;")
+    actual_ast = _parser.Parser(tokenizer).parse()
     assert actual_ast == expected_ast
 
 
@@ -65,17 +49,8 @@ precedence_and_or_tests = [
 
 @pytest.mark.parametrize("test_name,operator_token", precedence_and_or_tests)
 def test_precedence_and_or(test_name, operator_token):
-    tokens = [
-        Token("1", INTEGER, 1),
-        Token("==", EQ, 1),
-        Token("1", INTEGER, 1),
-        operator_token,
-        Token("2", INTEGER, 1),
-        Token("!=", NE, 1),
-        Token("3", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-        Token("", EOF, 1)
-    ]
+
+    tokenizer = Tokenizer(f"1 == 1 {operator_token.value} 2 != 3;")
 
     expected_ast = [
         _parser.ExpressionStatement(
@@ -95,5 +70,5 @@ def test_precedence_and_or(test_name, operator_token):
         )
     ]
 
-    actual_ast = _parser.Parser(tokens).parse()
+    actual_ast = _parser.Parser(tokenizer).parse()
     assert actual_ast == expected_ast

--- a/tests/test_parser_unit.py
+++ b/tests/test_parser_unit.py
@@ -2,19 +2,13 @@ import pytest
 
 from _parser._parser import Parser
 from _parser.ast_objects import *
-from tokens.tokenizer import Token
+from tokens.tokenizer import Token, Tokenizer
 
 
 def test_set_statement():
-    tokens = [
-        Token("set", SET, 1),
-        Token("variable", IDENTIFIER, 1),
-        Token("=", ASSIGN, 1),
-        Token("1", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-    ]
+    tokenizer = Tokenizer("set variable = 1;")
+    p = Parser(tokenizer)
 
-    p = Parser(tokens)
     actual_assign_ast = p.assign()
     expected_assign_ast = SetVariable(
         Identifier("variable", 1),
@@ -32,17 +26,14 @@ operate_assign_tests = [
 
 @pytest.mark.parametrize("operator_assign_literal, operator_assign_type, operator_literal, operator_type", operate_assign_tests)
 def test_set_statement_operate_assign(operator_assign_literal, operator_assign_type, operator_literal, operator_type):
-    variable_name = "variable"
-    identifier_token = Identifier(variable_name, 1)
-    tokens = [
-        Token("set", SET, 1),
-        Token(variable_name, IDENTIFIER, 1),
-        Token(operator_assign_literal, operator_assign_type, 1),
-        Token("1", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-    ]
 
-    p = Parser(tokens)
+    variable_name = "variable"
+    source = f"set {variable_name} {operator_assign_literal} 1;"
+    tokenizer = Tokenizer(source)
+
+    identifier_token = Identifier(variable_name, 1)
+
+    p = Parser(tokenizer)
     actual_assign_ast = p.assign()
     expected_assign_ast = SetVariable(
         identifier_token,
@@ -55,22 +46,11 @@ def test_set_statement_operate_assign(operator_assign_literal, operator_assign_t
 
 
 def test_loop():
-    tokens = [
-        Token("while", WHILE, 1),
-        Token("i", IDENTIFIER, 1),
-        Token("<", LT, 1),
-        Token("10", INTEGER, 1),
-        Token("{", OPEN_CURLY_BRACKET, 1),
-        Token("set", SET, 2),
-        Token("i", IDENTIFIER, 2),
-        Token("+=", ASSIGN_ADD, 2),
-        Token("1", INTEGER, 2),
-        Token(";", SEMICOLON, 2),
-        Token("}", CLOSED_CURLY_BRACKET, 3),
-        Token(";", SEMICOLON, 3),
-    ]
 
-    p = Parser(tokens)
+    source = "while i < 10 {\n set i += 1; };"
+    tokenizer = Tokenizer(source)
+
+    p = Parser(tokenizer)
     actual_loop_ast = p.loop()
     expected_loop_ast = Loop(
         BinaryOperation(Identifier("i", 1), Token("<", LT, 1), Integer(10, 1)),

--- a/tests/test_tokenizer_integration.py
+++ b/tests/test_tokenizer_integration.py
@@ -4,25 +4,32 @@ from tokens.tokenizer import Tokenizer, Token
 
 data_types_tests = [
     ("\"hello, world!\"", [
-        Token("hello, world!", STRING, 1)
+        Token("hello, world!", STRING, 1),
+        Token("", EOF, 1)
     ]),
     ("true", [
-        Token("true", BOOLEAN, 1)
+        Token("true", BOOLEAN, 1),
+        Token("", EOF, 1)
     ]),
     ("false", [
-        Token("false", BOOLEAN, 1)
+        Token("false", BOOLEAN, 1),
+        Token("", EOF, 1)
     ]),
     ("1", [
-        Token("1", INTEGER, 1)
+        Token("1", INTEGER, 1),
+        Token("", EOF, 1)
     ]),
     ("15", [
-        Token("15", INTEGER, 1)
+        Token("15", INTEGER, 1),
+        Token("", EOF, 1)
     ]),
     ("153", [
-        Token("153", INTEGER, 1)
+        Token("153", INTEGER, 1),
+        Token("", EOF, 1)
     ]),
     ("1.5", [
-        Token("1.5", FLOAT, 1)
+        Token("1.5", FLOAT, 1),
+        Token("", EOF, 1)
     ]),
 ]
 
@@ -38,7 +45,8 @@ tokenizer_tests = [
         Token("1", INTEGER, 1),
         Token("+", PLUS, 1),
         Token("1", INTEGER, 1),
-        Token(";", SEMICOLON, 1)
+        Token(";", SEMICOLON, 1),
+        Token("", EOF, 1)
     ]),
     ("a = 1;\nb = 2;", [
         Token("a", IDENTIFIER, 1),
@@ -48,19 +56,22 @@ tokenizer_tests = [
         Token("b", IDENTIFIER, 2),
         Token("=", ASSIGN, 2),
         Token("2", INTEGER, 2),
-        Token(";", SEMICOLON, 2)
+        Token(";", SEMICOLON, 2),
+        Token("", EOF, 2)
     ]),
     ("# a = 1;\nb = 2;", [
         Token("b", IDENTIFIER, 2),
         Token("=", ASSIGN, 2),
         Token("2", INTEGER, 2),
-        Token(";", SEMICOLON, 2)
+        Token(";", SEMICOLON, 2),
+        Token("", EOF, 2)
     ]),
     ("\n/*x = 1;\nb = 2; */\nc = 3;", [
         Token("c", IDENTIFIER, 4),
         Token("=", ASSIGN, 4),
         Token("3", INTEGER, 4),
-        Token(";", SEMICOLON, 4)
+        Token(";", SEMICOLON, 4),
+        Token("", EOF, 4)
     ]),
     ("/*func is_eq(a, b) {\n    return a == b;\n};\n*/print(1 / 1);", [
         Token("print", IDENTIFIER, 4),
@@ -69,7 +80,8 @@ tokenizer_tests = [
         Token("/", DIVIDE, 4),
         Token("1", INTEGER, 4),
         Token(")", CLOSED_PAREN, 4),
-        Token(";", SEMICOLON, 4)
+        Token(";", SEMICOLON, 4),
+        Token("", EOF, 4)
     ]),
     ("i += 3; j -= 4;\nk *= 5; l /= 6;", [
         Token("i", IDENTIFIER, 1),
@@ -87,7 +99,8 @@ tokenizer_tests = [
         Token("l", IDENTIFIER, 2),
         Token("/=", ASSIGN_DIV, 2),
         Token("6", INTEGER, 2),
-        Token(";", SEMICOLON, 2)
+        Token(";", SEMICOLON, 2),
+        Token("", EOF, 2)
     ])
 ]
 

--- a/tests/test_tokenizer_integration.py
+++ b/tests/test_tokenizer_integration.py
@@ -4,39 +4,32 @@ from tokens.tokenizer import Tokenizer, Token
 
 data_types_tests = [
     ("\"hello, world!\"", [
-        Token("hello, world!", STRING, 1),
-        Token("", EOF, 1),
+        Token("hello, world!", STRING, 1)
     ]),
     ("true", [
-        Token("true", BOOLEAN, 1),
-        Token("", EOF, 1),
+        Token("true", BOOLEAN, 1)
     ]),
     ("false", [
-        Token("false", BOOLEAN, 1),
-        Token("", EOF, 1),
+        Token("false", BOOLEAN, 1)
     ]),
     ("1", [
-        Token("1", INTEGER, 1),
-        Token("", EOF, 1),
+        Token("1", INTEGER, 1)
     ]),
     ("15", [
-        Token("15", INTEGER, 1),
-        Token("", EOF, 1),
+        Token("15", INTEGER, 1)
     ]),
     ("153", [
-        Token("153", INTEGER, 1),
-        Token("", EOF, 1),
+        Token("153", INTEGER, 1)
     ]),
     ("1.5", [
-        Token("1.5", FLOAT, 1),
-        Token("", EOF, 1),
+        Token("1.5", FLOAT, 1)
     ]),
 ]
 
 
 @pytest.mark.parametrize("source,expected_tokens", data_types_tests)
 def test_data_types(source, expected_tokens):
-    actual_tokens = Tokenizer(source).tokenize()
+    actual_tokens = get_tokens(source)
     assert actual_tokens == expected_tokens
 
 
@@ -45,8 +38,7 @@ tokenizer_tests = [
         Token("1", INTEGER, 1),
         Token("+", PLUS, 1),
         Token("1", INTEGER, 1),
-        Token(";", SEMICOLON, 1),
-        Token("", EOF, 1)
+        Token(";", SEMICOLON, 1)
     ]),
     ("a = 1;\nb = 2;", [
         Token("a", IDENTIFIER, 1),
@@ -56,22 +48,19 @@ tokenizer_tests = [
         Token("b", IDENTIFIER, 2),
         Token("=", ASSIGN, 2),
         Token("2", INTEGER, 2),
-        Token(";", SEMICOLON, 2),
-        Token("", EOF, 2),
+        Token(";", SEMICOLON, 2)
     ]),
     ("# a = 1;\nb = 2;", [
         Token("b", IDENTIFIER, 2),
         Token("=", ASSIGN, 2),
         Token("2", INTEGER, 2),
-        Token(";", SEMICOLON, 2),
-        Token("", EOF, 2),
+        Token(";", SEMICOLON, 2)
     ]),
     ("\n/*x = 1;\nb = 2; */\nc = 3;", [
         Token("c", IDENTIFIER, 4),
         Token("=", ASSIGN, 4),
         Token("3", INTEGER, 4),
-        Token(";", SEMICOLON, 4),
-        Token("", EOF, 4),
+        Token(";", SEMICOLON, 4)
     ]),
     ("/*func is_eq(a, b) {\n    return a == b;\n};\n*/print(1 / 1);", [
         Token("print", IDENTIFIER, 4),
@@ -80,8 +69,7 @@ tokenizer_tests = [
         Token("/", DIVIDE, 4),
         Token("1", INTEGER, 4),
         Token(")", CLOSED_PAREN, 4),
-        Token(";", SEMICOLON, 4),
-        Token("", EOF, 4),
+        Token(";", SEMICOLON, 4)
     ]),
     ("i += 3; j -= 4;\nk *= 5; l /= 6;", [
         Token("i", IDENTIFIER, 1),
@@ -99,13 +87,16 @@ tokenizer_tests = [
         Token("l", IDENTIFIER, 2),
         Token("/=", ASSIGN_DIV, 2),
         Token("6", INTEGER, 2),
-        Token(";", SEMICOLON, 2),
-        Token("", EOF, 2),
+        Token(";", SEMICOLON, 2)
     ])
 ]
 
 
 @pytest.mark.parametrize("source, expected_tokens", tokenizer_tests)
 def test_tokenizer(source, expected_tokens):
-    actual_tokens = Tokenizer(source).tokenize()
+    actual_tokens = get_tokens(source)
     assert actual_tokens == expected_tokens
+
+
+def get_tokens(source: str) -> list[Token]:
+    return [t for t in Tokenizer(source)]

--- a/tests/test_tokenizer_unit.py
+++ b/tests/test_tokenizer_unit.py
@@ -182,5 +182,5 @@ def test_advance():
         assert tokenizer.index == i
         tokenizer.advance()
 
-    assert tokenizer.current is None
+    assert tokenizer.current is None  # current is a property and acts like a method call
     assert tokenizer.index == len(source)

--- a/tokens/tokenizer.py
+++ b/tokens/tokenizer.py
@@ -34,6 +34,9 @@ class Tokenizer:
         self.index: int = 0
         self.line_num: int = 1
         self.line_col: int = 1
+
+        # If self.current is None, the tokenizer should return an EOF token. When that happens, this variable will be
+        # set to true, and the next time .next_token is called, a StopIteration exception is raised.
         self.is_end_of_stream: bool = False
 
     def __iter__(self) -> "Tokenizer":

--- a/tokens/tokenizer.py
+++ b/tokens/tokenizer.py
@@ -34,13 +34,18 @@ class Tokenizer:
         self.index: int = 0
         self.line_num: int = 1
         self.line_col: int = 1
+        self.is_end_of_stream: bool = False
 
     def __iter__(self) -> "Tokenizer":
         return self
 
     def __next__(self) -> Token:
-        if self.current is None:
+        if self.is_end_of_stream:
             raise StopIteration
+
+        if self.current is None:
+            self.is_end_of_stream = True
+
         return self.next_token()
 
     def next_token(self) -> Token:
@@ -48,7 +53,7 @@ class Tokenizer:
         self.skip_comments()
 
         if self.current is None:
-            raise StopIteration
+            return Token("", EOF, self.line_num)
 
         elif self.is_digit():
             number: str = self.read_number()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -44,6 +44,10 @@ def raise_error(line_num: int, description: str) -> typing.NoReturn:
     raise LanguageRuntimeException(f"Error at line {line_num}: {description}")
 
 
+def raise_unexpected_end_of_file() -> typing.NoReturn:
+    raise LanguageRuntimeException("Unexpected end of file")
+
+
 def get(dictionary: dict[str, typing.Any], key_path: str) -> typing.Any:
     value = dictionary
     for key in key_path.split("."):


### PR DESCRIPTION
This change updates the tokenizer to use lazy evaluation, which retrieves each token as needed as opposed to retrieving all tokens in the source code at once (returning an array/list of tokens). The reason for this change is to reduce the amount of data stored in memory.

Considerations
* Right now, for block statements associated with loops, if-statements, function declarations, etc. I'm adding semicolons so the user doesn't have to. This might be difficult to do in this implementation. Can they be added to the peek queue?
* `self.current` being None causes issues with mypy. Can we use a `self.current` property (might cause issues with adding semicolons to token stream)?